### PR TITLE
fix: Correct dynamic matrix population in GitHub workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,30 +9,39 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push-images:
+  list_images_job:
+    name: Determine Images to Build
     runs-on: ubuntu-latest
+    outputs:
+      matrix_json_string: ${{ steps.generate_matrix.outputs.matrix_string }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Generate image matrix string
+        id: generate_matrix
+        run: |
+          IMAGES_JSON=$(ls -1 docker/ | grep -v '^$' | jq -R . | jq -s .)
+          echo "matrix_string=${IMAGES_JSON}" >> $GITHUB_OUTPUT
+          echo "Generated matrix: ${IMAGES_JSON}"
+
+  build-and-push-images:
+    name: Build and Push Images
+    runs-on: ubuntu-latest
+    needs: list_images_job
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
       matrix:
-        image: [] # This will be populated by the list_images step
+        image: ${{ fromJSON(needs.list_images_job.outputs.matrix_json_string) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: List images for matrix
-        id: list_images
-        run: |
-          IMAGES=$(ls docker | tr '\n' ' ')
-          echo "images_json=[\"$(echo $IMAGES | sed 's/ /","/g')\"]" >> $GITHUB_OUTPUT
-
-      - name: Set matrix for job
-        run: |
-          echo "Using images: ${{ steps.list_images.outputs.images_json }}"
-          echo "::set-output name=matrix::{\"image\":${{ steps.list_images.outputs.images_json }}}"
-        id: set_matrix # Give this step an id to reference its output if needed later, though matrix is set directly for the job
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This commit fixes an issue in the GitHub Actions workflow (`.github/workflows/docker-build.yml`) where the build matrix for Docker images was not being populated correctly. The error "Matrix vector 'image' does not contain any values" occurred because a job cannot dynamically set its own strategy matrix from one of its own steps.

The workflow has been refactored to use a two-job approach:

1.  **`list_images_job` (New Job):**
    *   This job runs first and is named "Determine Images to Build".
    *   It checks out the code, lists subdirectories under the `docker/` directory, and uses `jq` to format these names into a JSON array string.
    *   This JSON array string is exposed as an output of this job (e.g., `outputs.matrix_json_string`).

2.  **`build-and-push-images` (Modified Job):**
    *   This job now `needs: list_images_job`.
    *   Its `strategy.matrix.image` is populated using `fromJSON(needs.list_images_job.outputs.matrix_json_string)`, which correctly consumes the output from the first job.
    *   The previous steps within this job that attempted to list images and set the matrix have been removed.

This change ensures that the build matrix is dynamically and correctly populated with the list of images to be built, allowing the workflow to proceed as intended.