### PR TITLE
Looks like I've got a fix for you!

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Generate image matrix string
         id: generate_matrix
         run: |
-          IMAGES_JSON=$(ls -1 docker/ | grep -v '^$' | jq -R . | jq -s .)
+          IMAGES_JSON=$(ls -1 docker/ | grep -v '^$' | jq -R . | jq -cs .)
           echo "matrix_string=${IMAGES_JSON}" >> $GITHUB_OUTPUT
           echo "Generated matrix: ${IMAGES_JSON}"
 


### PR DESCRIPTION
**fix: Ensure compact JSON output for workflow matrix**

This change addresses an error in your GitHub Actions workflow (`.github/workflows/docker-build.yml`). It seems the `matrix_string` being output by the `list_images_job` was causing an "Invalid format" error.

The problem was that the command used to create the JSON array of image names could sometimes produce a multi-line string. When this multi-line string was sent as output for GitHub Actions, it caused an issue because GitHub Actions expects outputs to be single-line strings.

To fix this, I've adjusted the command in the "Generate image matrix string" step to ensure the resulting JSON array is always a single line.

This should make sure the `matrix_string` output is formatted correctly and can be understood by GitHub Actions, allowing your build matrix to populate without any further errors.