### PR TITLE
feat: Add startup tests for images in CI workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,6 +62,36 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Build and load test image for ${{ matrix.image }} (amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/${{ matrix.image }}
+          file: docker/${{ matrix.image }}/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: ${{ matrix.image }}:test-amd64
+          outputs: type=image,name=${{ matrix.image }},oci-mediatypes=true,compression=estargz,force-compression=true,store=true
+
+      - name: Test loaded image ${{ matrix.image }}
+        run: |
+          echo "Testing image: ${{ matrix.image }}"
+          IMAGE_NAME="${{ matrix.image }}"
+          TEST_TAG="test-amd64"
+          # Default test command assumes the entrypoint binary supports --version or similar
+          TEST_CMD="--version"
+
+          # Specific command overrides
+          if [ "$IMAGE_NAME" = "dig" ]; then
+            TEST_CMD="-v"
+          elif [ "$IMAGE_NAME" = "nettools" ]; then
+            # For nettools, the entrypoint is netdiag; running without args is the test
+            docker run --rm "${IMAGE_NAME}:${TEST_TAG}"
+            exit 0 # Exit successfully if docker run completes
+          fi
+
+          # General test execution
+          docker run --rm "${IMAGE_NAME}:${TEST_TAG}" $TEST_CMD
+
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
This commit enhances the Docker image build workflow (`.github/workflows/docker-build.yml`) by adding a unit test step for each image built. The test verifies that the primary binary in each image can be started without error.

Key changes to the `build-and-push-images` job:

1.  **Build and Load for Test:**
    *   A new step "Build and load test image for ... (amd64)" has been added.
    *   This step builds the current matrix image specifically for the `linux/amd64` platform and loads it into the Docker daemon on the GitHub Actions runner with a temporary tag (e.g., `image_name:test-amd64`).

2.  **Image Startup Test:**
    *   A new step "Test loaded image ..." has been added following the load step.
    *   This step runs a basic command against the loaded test image to ensure its primary executable starts correctly.
    *   Test commands are typically `--version` or similar flags (e.g., `dig -v`).
    *   For the `nettools` image, it runs the main `netdiag` application entrypoint.
    *   If this test step fails, the workflow for that specific image will fail, preventing a potentially broken image from being pushed.

3.  **Multi-Platform Push:**
    *   The original "Build and push multi-arch image" step remains and will only execute if the preceding build and test steps for the amd64 version are successful.

This change provides an early validation check for each image, ensuring that the entrypoint binary is runnable before the image is pushed to container registries.