### PR TITLE
fix: Correct test command for ping image in CI workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -83,6 +83,8 @@ jobs:
           # Specific command overrides
           if [ "$IMAGE_NAME" = "dig" ]; then
             TEST_CMD="-v"
+          elif [ "$IMAGE_NAME" = "ping" ]; then
+            TEST_CMD="-V"
           elif [ "$IMAGE_NAME" = "nettools" ]; then
             # For nettools, the entrypoint is netdiag; running without args is the test
             docker run --rm "${IMAGE_NAME}:${TEST_TAG}"


### PR DESCRIPTION
This commit updates the test command used for the `ping` Docker image within the GitHub Actions workflow (`.github/workflows/docker-build.yml`).

The previous default test command `--version` was causing an error with the `iputils-ping` version present in the image, as it does not support this option. The error was "/bin/ping: invalid option -- '-'".

The test command for the `ping` image has been changed to `-V` (uppercase V), which is the correct option to print version information and exit for this version of `ping`, as indicated by its help output.