### PR TITLE
feat: Add nping image and fix traceroute startup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -85,6 +85,8 @@ jobs:
             TEST_CMD="-v"
           elif [ "$IMAGE_NAME" = "ping" ]; then
             TEST_CMD="-V"
+          elif [ "$IMAGE_NAME" = "nping" ]; then
+            TEST_CMD="--version"
           elif [ "$IMAGE_NAME" = "nettools" ]; then
             # For nettools, the entrypoint is netdiag; running without args is the test
             docker run --rm "${IMAGE_NAME}:${TEST_TAG}"

--- a/docker/nping/Dockerfile
+++ b/docker/nping/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Builder
+ARG DEBIAN_VERSION=12-slim
+FROM debian:${DEBIAN_VERSION} AS builder
+
+RUN apt-get update &&     apt-get install -y --no-install-recommends     nmap     && rm -rf /var/lib/apt/lists/*
+
+RUN     # Determine actual installed path of nping
+    ACTUAL_NPING_PATH=$(which nping) &&     if [ -z "$ACTUAL_NPING_PATH" ]; then         echo "Error: nping command not found in PATH after installation." >&2;         exit 1;     fi &&     echo "Nping found at: $ACTUAL_NPING_PATH" &&         # Define a consistent target path for the binary in staging & final image
+    TARGET_NPING_PATH_IN_IMAGE="/usr/bin/nping" &&         # Create the directory for the binary in staging
+    mkdir -p "/staging_root_nping$(dirname "$TARGET_NPING_PATH_IN_IMAGE")" &&         # Copy the nping binary to the target path in staging
+    cp "$ACTUAL_NPING_PATH" "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     chmod +x "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     echo "Staged nping to /staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&         # Copy library dependencies based on the actual binary path
+    ldd "$ACTUAL_NPING_PATH" | grep "=>" | awk '{print $3}' | grep -v "^$" | while read lib_path; do         if [ -f "$lib_path" ]; then             mkdir -p "/staging_root_nping$(dirname "$lib_path")";             cp -L "$lib_path" "/staging_root_nping$lib_path";             echo "Copied library: $lib_path";         fi     done &&         # Also copy the dynamic linker/loader itself
+    ldd "$ACTUAL_NPING_PATH" | awk '/\/lib(64|)\/ld-linux(.*)\.so\.([0-9]+)/{print $1}' | while read ld_path; do         if [ -f "$ld_path" ]; then             mkdir -p "/staging_root_nping$(dirname "$ld_path")";             cp -L "$ld_path" "/staging_root_nping$ld_path";             echo "Copied dynamic loader: $ld_path";         fi     done
+    # Note: nping might sometimes need data files from /usr/share/nmap for certain operations.
+    # For now, we are only packaging the binary and its direct libs for basic functionality.
+    # If extended features are needed, /usr/share/nmap (or parts of it) might need to be copied.
+
+# Stage 2: Final Image
+FROM gcr.io/distroless/base-debian12 AS final
+
+ARG TARGETPLATFORM
+ARG DEBIAN_VERSION=12-slim # For labeling consistency, though base is fixed
+
+COPY --from=builder /staging_root_nping/ /
+
+LABEL org.opencontainers.image.authors="kevin@kubebee.com"
+LABEL org.opencontainers.image.architecture=$TARGETPLATFORM
+LABEL name="nping"
+LABEL version="debian${DEBIAN_VERSION}-distroless"
+
+WORKDIR /
+ENTRYPOINT ["/usr/bin/nping"]
+CMD ["--version"]

--- a/docker/traceroute/Dockerfile
+++ b/docker/traceroute/Dockerfile
@@ -8,30 +8,38 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    traceroute \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /staging_root && \
-    TRACEROUTE_PATH=$(which traceroute) && \
-    echo "Traceroute found at: $TRACEROUTE_PATH" && \
-    mkdir -p "/staging_root$(dirname "$TRACEROUTE_PATH")" && \
-    cp "$TRACEROUTE_PATH" "/staging_root$TRACEROUTE_PATH" && \
-    chmod +x "/staging_root$TRACEROUTE_PATH" && \
-    # Identify and copy library dependencies
-    ldd "$TRACEROUTE_PATH" | grep "=>" | awk '{print $3}' | grep -v "^$" | while read lib_path; do \
+    apt-get install -y --no-install-recommends traceroute && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Determine actual installed path of traceroute
+    ACTUAL_TRACEROUTE_PATH=$(which traceroute) && \
+    if [ -z "$ACTUAL_TRACEROUTE_PATH" ]; then \
+        echo "Error: traceroute command not found in PATH after installation." >&2; \
+        exit 1; \
+    fi && \
+    echo "Traceroute found at: $ACTUAL_TRACEROUTE_PATH" && \
+    # Define a consistent target path for the binary in staging & final image
+    # This path should match the ENTRYPOINT declaration
+    TARGET_TRACEROUTE_PATH_IN_IMAGE="/usr/bin/traceroute" && \
+    # Create the directory for the binary in staging
+    mkdir -p "/staging_root$(dirname "$TARGET_TRACEROUTE_PATH_IN_IMAGE")" && \
+    # Copy the traceroute binary to the target path in staging
+    cp "$ACTUAL_TRACEROUTE_PATH" "/staging_root$TARGET_TRACEROUTE_PATH_IN_IMAGE" && \
+    chmod +x "/staging_root$TARGET_TRACEROUTE_PATH_IN_IMAGE" && \
+    echo "Staged traceroute to /staging_root$TARGET_TRACEROUTE_PATH_IN_IMAGE" && \
+    # Copy library dependencies based on the actual binary path
+    ldd "$ACTUAL_TRACEROUTE_PATH" | grep "=>" | awk '{print $3}' | grep -v "^$" | while read lib_path; do \
         if [ -f "$lib_path" ]; then \
             mkdir -p "/staging_root$(dirname "$lib_path")"; \
             cp -L "$lib_path" "/staging_root$lib_path"; \
-            echo "Copied $lib_path"; \
+            echo "Copied library: $lib_path"; \
         fi \
     done && \
-    # Also copy the dynamic linker/loader itself if present in ldd output
-    ldd "$TRACEROUTE_PATH" | awk '/\/lib(64|)\/ld-linux(.*)\.so\.([0-9]+)/{print $1}' | while read ld_path; do \
+    # Also copy the dynamic linker/loader itself
+    ldd "$ACTUAL_TRACEROUTE_PATH" | awk '/\/lib(64|)\/ld-linux(.*)\.so\.([0-9]+)/{print $1}' | while read ld_path; do \
         if [ -f "$ld_path" ]; then \
             mkdir -p "/staging_root$(dirname "$ld_path")"; \
             cp -L "$ld_path" "/staging_root$ld_path"; \
-            echo "Copied loader $ld_path"; \
+            echo "Copied dynamic loader: $ld_path"; \
         fi \
     done
 


### PR DESCRIPTION
This commit introduces a new Docker image for `nping` and resolves a runtime error in the `traceroute` image test.

1.  **Fix `traceroute` Image Startup Error:**
    *   Modified `docker/traceroute/Dockerfile` to ensure the `traceroute` binary is reliably copied to `/usr/bin/traceroute` in the final image, matching its `ENTRYPOINT`.
    *   This resolves the "stat /usr/bin/traceroute: no such file or directory" error previously encountered during CI tests.

2.  **Add `nping` Docker Image:**
    *   Created `docker/nping/Dockerfile` and the `docker/nping/` directory.
    *   The Dockerfile builds `nping` (included with the `nmap` package) into a distroless base image (`gcr.io/distroless/base-debian12`).
    *   It uses a multi-stage build to copy the `nping` binary and its dependencies.
    *   The image entrypoint is `/usr/bin/nping`, with a default command of `--version`.

3.  **Update GitHub Workflow for `nping` Test:**
    *   Added a test case to the CI workflow (`.github/workflows/docker-build.yml`) for the new `nping` image. The test runs `nping --version` to verify the binary starts correctly.