### PR TITLE
Fix: Correct Dockerfile errors in nping and nettools images

### DIFF
--- a/docker/nettools/Dockerfile
+++ b/docker/nettools/Dockerfile
@@ -23,6 +23,7 @@ ARG DEBIAN_VERSION=12 # As per original tcpdump Dockerfile for this stage
 FROM debian:12-slim AS tcpdump-prep-builder-base
 
 # Copy base /etc/group and /etc/passwd from a distroless image to modify
+ARG DEBIAN_VERSION=12
 FROM gcr.io/distroless/base-debian${DEBIAN_VERSION} AS tcpdump-distroless-files
 COPY /etc/group /etc/passwd /tmp/distroless-etc/
 

--- a/docker/nping/Dockerfile
+++ b/docker/nping/Dockerfile
@@ -4,14 +4,12 @@
 ARG DEBIAN_VERSION=12-slim
 FROM debian:${DEBIAN_VERSION} AS builder
 
-RUN apt-get update &&     apt-get install -y --no-install-recommends     nmap     && rm -rf /var/lib/apt/lists/*
-
-RUN     # Determine actual installed path of nping
-    ACTUAL_NPING_PATH=$(which nping) &&     if [ -z "$ACTUAL_NPING_PATH" ]; then         echo "Error: nping command not found in PATH after installation." >&2;         exit 1;     fi &&     echo "Nping found at: $ACTUAL_NPING_PATH" &&         # Define a consistent target path for the binary in staging & final image
-    TARGET_NPING_PATH_IN_IMAGE="/usr/bin/nping" &&         # Create the directory for the binary in staging
-    mkdir -p "/staging_root_nping$(dirname "$TARGET_NPING_PATH_IN_IMAGE")" &&         # Copy the nping binary to the target path in staging
-    cp "$ACTUAL_NPING_PATH" "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     chmod +x "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     echo "Staged nping to /staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&         # Copy library dependencies based on the actual binary path
-    ldd "$ACTUAL_NPING_PATH" | grep "=>" | awk '{print $3}' | grep -v "^$" | while read lib_path; do         if [ -f "$lib_path" ]; then             mkdir -p "/staging_root_nping$(dirname "$lib_path")";             cp -L "$lib_path" "/staging_root_nping$lib_path";             echo "Copied library: $lib_path";         fi     done &&         # Also copy the dynamic linker/loader itself
+RUN apt-get update &&     apt-get install -y --no-install-recommends     nmap     && rm -rf /var/lib/apt/lists/* &&     # Determine actual installed path of nping
+    ACTUAL_NPING_PATH=$(which nping) &&     if [ -z "$ACTUAL_NPING_PATH" ]; then         echo "Error: nping command not found in PATH after installation." >&2;         exit 1;     fi &&     echo "Nping found at: $ACTUAL_NPING_PATH" &&     # Define a consistent target path for the binary in staging & final image
+    TARGET_NPING_PATH_IN_IMAGE="/usr/bin/nping" &&     # Create the directory for the binary in staging
+    mkdir -p "/staging_root_nping$(dirname "$TARGET_NPING_PATH_IN_IMAGE")" &&     # Copy the nping binary to the target path in staging
+    cp "$ACTUAL_NPING_PATH" "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     chmod +x "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     echo "Staged nping to /staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     # Copy library dependencies based on the actual binary path
+    ldd "$ACTUAL_NPING_PATH" | grep "=>" | awk '{print $3}' | grep -v "^$" | while read lib_path; do         if [ -f "$lib_path" ]; then             mkdir -p "/staging_root_nping$(dirname "$lib_path")";             cp -L "$lib_path" "/staging_root_nping$lib_path";             echo "Copied library: $lib_path";         fi     done &&     # Also copy the dynamic linker/loader itself
     ldd "$ACTUAL_NPING_PATH" | awk '/\/lib(64|)\/ld-linux(.*)\.so\.([0-9]+)/{print $1}' | while read ld_path; do         if [ -f "$ld_path" ]; then             mkdir -p "/staging_root_nping$(dirname "$ld_path")";             cp -L "$ld_path" "/staging_root_nping$ld_path";             echo "Copied dynamic loader: $ld_path";         fi     done
     # Note: nping might sometimes need data files from /usr/share/nmap for certain operations.
     # For now, we are only packaging the binary and its direct libs for basic functionality.


### PR DESCRIPTION
This commit addresses two build errors in Dockerfiles:

1.  **nping Dockerfile:** A syntax error was corrected where shell commands for finding and staging the `nping` binary and its dependencies were outside a `RUN` instruction. These have been moved into the appropriate `RUN` block.

2.  **nettools Dockerfile:** An error due to `DEBIAN_VERSION` being undefined in the scope of a `FROM` instruction was fixed. `ARG DEBIAN_VERSION=12` has been added before the `FROM gcr.io/distroless/base-debian${DEBIAN_VERSION} AS tcpdump-distroless-files` line to correctly scope the argument.