### PR TITLE
Fix: Correct Dockerfile syntax for nping

### DIFF
--- a/docker/nping/Dockerfile
+++ b/docker/nping/Dockerfile
@@ -4,13 +4,40 @@
 ARG DEBIAN_VERSION=12-slim
 FROM debian:${DEBIAN_VERSION} AS builder
 
-RUN apt-get update &&     apt-get install -y --no-install-recommends     nmap     && rm -rf /var/lib/apt/lists/* &&     # Determine actual installed path of nping
-    ACTUAL_NPING_PATH=$(which nping) &&     if [ -z "$ACTUAL_NPING_PATH" ]; then         echo "Error: nping command not found in PATH after installation." >&2;         exit 1;     fi &&     echo "Nping found at: $ACTUAL_NPING_PATH" &&     # Define a consistent target path for the binary in staging & final image
-    TARGET_NPING_PATH_IN_IMAGE="/usr/bin/nping" &&     # Create the directory for the binary in staging
-    mkdir -p "/staging_root_nping$(dirname "$TARGET_NPING_PATH_IN_IMAGE")" &&     # Copy the nping binary to the target path in staging
-    cp "$ACTUAL_NPING_PATH" "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     chmod +x "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     echo "Staged nping to /staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" &&     # Copy library dependencies based on the actual binary path
-    ldd "$ACTUAL_NPING_PATH" | grep "=>" | awk '{print $3}' | grep -v "^$" | while read lib_path; do         if [ -f "$lib_path" ]; then             mkdir -p "/staging_root_nping$(dirname "$lib_path")";             cp -L "$lib_path" "/staging_root_nping$lib_path";             echo "Copied library: $lib_path";         fi     done &&     # Also copy the dynamic linker/loader itself
-    ldd "$ACTUAL_NPING_PATH" | awk '/\/lib(64|)\/ld-linux(.*)\.so\.([0-9]+)/{print $1}' | while read ld_path; do         if [ -f "$ld_path" ]; then             mkdir -p "/staging_root_nping$(dirname "$ld_path")";             cp -L "$ld_path" "/staging_root_nping$ld_path";             echo "Copied dynamic loader: $ld_path";         fi     done
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nmap && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Determine actual installed path of nping
+    ACTUAL_NPING_PATH=$(which nping) && \
+    if [ -z "$ACTUAL_NPING_PATH" ]; then \
+        echo "Error: nping command not found in PATH after installation." >&2; \
+        exit 1; \
+    fi && \
+    echo "Nping found at: $ACTUAL_NPING_PATH" && \
+    # Define a consistent target path for the binary in staging & final image
+    TARGET_NPING_PATH_IN_IMAGE="/usr/bin/nping" && \
+    # Create the directory for the binary in staging
+    mkdir -p "/staging_root_nping$(dirname "$TARGET_NPING_PATH_IN_IMAGE")" && \
+    # Copy the nping binary to the target path in staging
+    cp "$ACTUAL_NPING_PATH" "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" && \
+    chmod +x "/staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" && \
+    echo "Staged nping to /staging_root_nping$TARGET_NPING_PATH_IN_IMAGE" && \
+    # Copy library dependencies based on the actual binary path
+    ldd "$ACTUAL_NPING_PATH" | grep "=>" | awk '{print $3}' | grep -v "^$" | while read lib_path; do \
+        if [ -f "$lib_path" ]; then \
+            mkdir -p "/staging_root_nping$(dirname "$lib_path")"; \
+            cp -L "$lib_path" "/staging_root_nping$lib_path"; \
+            echo "Copied library: $lib_path"; \
+        fi \
+    done && \
+    # Also copy the dynamic linker/loader itself
+    ldd "$ACTUAL_NPING_PATH" | awk '/\/lib(64|)\/ld-linux(.*)\.so\.([0-9]+)/{print $1}' | while read ld_path; do \
+        if [ -f "$ld_path" ]; then \
+            mkdir -p "/staging_root_nping$(dirname "$ld_path")"; \
+            cp -L "$ld_path" "/staging_root_nping$ld_path"; \
+            echo "Copied dynamic loader: $ld_path"; \
+        fi \
+    done
     # Note: nping might sometimes need data files from /usr/share/nmap for certain operations.
     # For now, we are only packaging the binary and its direct libs for basic functionality.
     # If extended features are needed, /usr/share/nmap (or parts of it) might need to be copied.


### PR DESCRIPTION
The previous Dockerfile for nping had multiple lines that were intended to be part of a single RUN instruction, but were incorrectly formatted as separate Dockerfile instructions. This caused a parse error during the Docker build process.

This commit consolidates these lines into the appropriate RUN instruction by appending '&& \' to each line, ensuring they are executed as a single shell command. This resolves the build failure.