### PR TITLE
Fix: Correct ARG scoping for DEBIAN_VERSION in nettools Dockerfile

### DIFF
--- a/docker/nettools/Dockerfile
+++ b/docker/nettools/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+ARG DEBIAN_VERSION=12
 
 #==============================================================================
 # Stage 1: netdiag-builder (C++ application)
@@ -19,11 +20,11 @@ RUN g++ main.cpp -o netdiag -static
 # Stage 2: tcpdump-prep
 # Adapting logic from the original docker/tcpdump/Dockerfile
 #==============================================================================
-ARG DEBIAN_VERSION=12 # As per original tcpdump Dockerfile for this stage
+# ARG DEBIAN_VERSION=12 # As per original tcpdump Dockerfile for this stage
 FROM debian:12-slim AS tcpdump-prep-builder-base
 
 # Copy base /etc/group and /etc/passwd from a distroless image to modify
-ARG DEBIAN_VERSION=12
+# ARG DEBIAN_VERSION=12
 FROM gcr.io/distroless/base-debian${DEBIAN_VERSION} AS tcpdump-distroless-files
 COPY /etc/group /etc/passwd /tmp/distroless-etc/
 
@@ -195,7 +196,7 @@ RUN SS_PATH=$(which ss) && \
 #==============================================================================
 FROM gcr.io/distroless/base-debian12 AS nettool-final
 ARG TARGETPLATFORM
-ARG DEBIAN_VERSION=12 # Match version used for distroless base
+# ARG DEBIAN_VERSION=12 # Match version used for distroless base
 
 LABEL org.opencontainers.image.authors="kevin@kubebee.com"
 LABEL org.opencontainers.image.architecture=${TARGETPLATFORM}


### PR DESCRIPTION
The Docker build for `docker/nettools/Dockerfile` was failing with an "image:latest not found" error and an "UndefinedArgInFrom" warning. This was due to how DEBIAN_VERSION was scoped when used in FROM lines.

This commit addresses the issue by:
1. Declaring `ARG DEBIAN_VERSION=12` globally at the top of the Dockerfile.
2. Commenting out shadowed `ARG DEBIAN_VERSION` declarations within specific stages that are now covered by the global ARG.

This ensures that `${DEBIAN_VERSION}` is correctly resolved to `12` for all `FROM` instructions, allowing the specified distroless base images (e.g., `gcr.io/distroless/base-debian12`) to be found correctly.